### PR TITLE
Remove underline underline in links on the web stats and change their colour

### DIFF
--- a/web/templates/duckstats_channel.twig
+++ b/web/templates/duckstats_channel.twig
@@ -76,6 +76,16 @@
             background: rgba(0, 0, 0, 0.04);
             max-width: 100%;
         }
+        
+        a:link, nav a:visited {
+            color: #70ACE9;
+            text-decoration: none;
+        }
+
+        a:hover, nav a:active {
+            color: #8AC7FF;
+            text-decoration: none;
+        }
     </style>
 
 

--- a/web/templates/duckstats_player.twig
+++ b/web/templates/duckstats_player.twig
@@ -78,7 +78,14 @@
 
         }
 
-
+        a:link, nav a:visited {
+            color: #70ACE9;
+            text-decoration: none;
+        }
+        a:hover, nav a:active {
+            color: #8AC7FF;
+            text-decoration: none;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
It is a bad web design practice to keep the underscore and change colour based on visited.
Here, the colour is the same regardless of visited or not, it is the default graph blue colour.
The hover or active (click) link is the hover colour of the graph.
I was taught to hate these underlines so I decided to fix it, enjoy <3

This PR fixes the templates for the Web, I'm not sure where exactly it was, so I kinda just went with it here.